### PR TITLE
Refactor backfill jobs into modular tasks with validation

### DIFF
--- a/ibx_flows/__init__.py
+++ b/ibx_flows/__init__.py
@@ -1,0 +1,1 @@
+"""Collection of data backfill and processing flows for the IB API."""

--- a/jobs/__init__.py
+++ b/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Job utilities and task definitions."""

--- a/jobs/backfill_equity_bars.py
+++ b/jobs/backfill_equity_bars.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
+
 import argparse
-from pathlib import Path
 from datetime import datetime
-from ibx_repos.equity_bars import EquityBarRepository
-from ibx_flows.backfill import BackfillConfig, backfill_equity_bars
-from ibx_flows.source_ib import IBSource
+from pathlib import Path
+
+from jobs.tasks import BackfillEquityBarsTask
 
 
 if __name__ == "__main__":
-    p = argparse.ArgumentParser();
-    p.add_argument("symbol")
-    p.add_argument("start")
-    p.add_argument("end")
-    p.add_argument("--bar", default="1 day");
-    p.add_argument("--out", type=Path, default=Path("data/equity_bars"))
-    args = p.parse_args()
-    cfg = BackfillConfig(underlying=args.symbol, start=datetime.fromisoformat(args.start).date(), end=datetime.fromisoformat(args.end).date(), bar_size=args.bar)
-    repo = EquityBarRepository(args.out); src = IBSource(); backfill_equity_bars(src, repo, cfg)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("symbol")
+    parser.add_argument("start")
+    parser.add_argument("end")
+    parser.add_argument("--bar", default="1 day")
+    parser.add_argument("--out", type=Path, default=Path("data/equity_bars"))
+    args = parser.parse_args()
+
+    task = BackfillEquityBarsTask(
+        symbol=args.symbol,
+        start=datetime.fromisoformat(args.start).date(),
+        end=datetime.fromisoformat(args.end).date(),
+        bar_size=args.bar,
+        out=args.out,
+    )
+    task.run()

--- a/jobs/backfill_option_bars.py
+++ b/jobs/backfill_option_bars.py
@@ -1,16 +1,34 @@
 from __future__ import annotations
+
 import argparse
-from pathlib import Path
 from datetime import datetime
-from ibx_repos.option_bars import OptionBarRepository
-from ibx_flows.backfill import BackfillConfig, backfill_option_bars
-from ibx_flows.source_ib import IBSource
+from pathlib import Path
+
+from jobs.tasks import BackfillOptionBarsTask
+
+
 if __name__ == "__main__":
-    p = argparse.ArgumentParser()
-    p.add_argument("symbol"); p.add_argument("start"); p.add_argument("end")
-    p.add_argument("--bar", default="1 day"); p.add_argument("--out", type=Path, default=Path("data/option_bars"))
-    p.add_argument("--expiries-max", type=int, default=8); p.add_argument("--strikes-per-side", type=int, default=6)
-    p.add_argument("--mode", choices=["k_around_atm","moneyness_bands"], default="k_around_atm")
-    args = p.parse_args()
-    cfg = BackfillConfig(underlying=args.symbol, start=datetime.fromisoformat(args.start).date(), end=datetime.fromisoformat(args.end).date(), bar_size=args.bar, expiries_max=args.expiries_max, strikes_per_side=args.strikes_per_side, selection_mode=args.mode)
-    repo = OptionBarRepository(args.out); src = IBSource(); backfill_option_bars(src, repo, chain_repo=None, eq_repo=None, cfg=cfg)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("symbol")
+    parser.add_argument("start")
+    parser.add_argument("end")
+    parser.add_argument("--bar", default="1 day")
+    parser.add_argument("--out", type=Path, default=Path("data/option_bars"))
+    parser.add_argument("--expiries-max", type=int, default=8)
+    parser.add_argument("--strikes-per-side", type=int, default=6)
+    parser.add_argument("--mode", choices=["k_around_atm", "moneyness_bands"], default="k_around_atm")
+    parser.add_argument("--chains", type=Path, default=Path("data"), help="Base path for chain repository")
+    args = parser.parse_args()
+
+    task = BackfillOptionBarsTask(
+        symbol=args.symbol,
+        start=datetime.fromisoformat(args.start).date(),
+        end=datetime.fromisoformat(args.end).date(),
+        bar_size=args.bar,
+        out=args.out,
+        chain_base=args.chains,
+        expiries_max=args.expiries_max,
+        strikes_per_side=args.strikes_per_side,
+        selection_mode=args.mode,
+    )
+    task.run()

--- a/jobs/tasks.py
+++ b/jobs/tasks.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+from ibx_flows.backfill import BackfillConfig, backfill_equity_bars, backfill_option_bars
+from ibx_flows.source_ib import IBSource
+from ibx_repos.equity_bars import EquityBarRepository
+from ibx_repos.option_bars import OptionBarRepository
+from option_repositories import ChainRepository
+
+
+class Task:
+    """Base class for runnable jobs with validation."""
+
+    def validate(self) -> None:  # pragma: no cover - override in subclasses
+        """Validate prerequisites for the task."""
+        return None
+
+    def execute(self) -> None:  # pragma: no cover - override in subclasses
+        raise NotImplementedError
+
+    def run(self) -> None:
+        """Validate then execute the task."""
+        self.validate()
+        self.execute()
+
+
+@dataclass
+class BackfillEquityBarsTask(Task):
+    symbol: str
+    start: date
+    end: date
+    bar_size: str = "1 day"
+    out: Path = Path("data/equity_bars")
+
+    def validate(self) -> None:
+        if self.start > self.end:
+            raise ValueError("start date must be on or before end date")
+
+    def execute(self) -> None:
+        cfg = BackfillConfig(
+            underlying=self.symbol,
+            start=self.start,
+            end=self.end,
+            bar_size=self.bar_size,
+        )
+        repo = EquityBarRepository(self.out)
+        src = IBSource()
+        backfill_equity_bars(src, repo, cfg)
+
+
+@dataclass
+class BackfillOptionBarsTask(Task):
+    symbol: str
+    start: date
+    end: date
+    bar_size: str = "1 day"
+    out: Path = Path("data/option_bars")
+    chain_base: Path = Path("data")
+    expiries_max: int = 8
+    strikes_per_side: int = 6
+    selection_mode: str = "k_around_atm"
+
+    _chain_repo: Optional[ChainRepository] = None
+
+    def validate(self) -> None:
+        chain_repo = ChainRepository(self.chain_base)
+        try:
+            df = chain_repo.load()
+        except Exception as exc:
+            raise FileNotFoundError(
+                f"No option chain data repository found at {chain_repo.base_path}"
+            ) from exc
+        if df.empty:
+            raise ValueError(
+                f"Option chain repository at {chain_repo.base_path} contains no data"
+            )
+        self._chain_repo = chain_repo
+
+    def execute(self) -> None:
+        if self._chain_repo is None:  # pragma: no cover - safety
+            raise RuntimeError("validate must be run before execute")
+        cfg = BackfillConfig(
+            underlying=self.symbol,
+            start=self.start,
+            end=self.end,
+            bar_size=self.bar_size,
+            expiries_max=self.expiries_max,
+            strikes_per_side=self.strikes_per_side,
+            selection_mode=self.selection_mode,
+        )
+        repo = OptionBarRepository(self.out)
+        src = IBSource()
+        backfill_option_bars(src, repo, chain_repo=self._chain_repo, eq_repo=None, cfg=cfg)


### PR DESCRIPTION
## Summary
- introduce reusable Task classes for backfill jobs with validation of prerequisite data
- update backfill job scripts to use modular tasks and check for existing chain data
- add package initializers for jobs and ibx_flows

## Testing
- `PYTHONPATH=. pytest` *(fails: IB not ready (nextValidId not received))*

------
https://chatgpt.com/codex/tasks/task_e_689b16972344832093dba5245f43c64e