### PR TITLE
refactor: centralize IB config

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,18 @@ from pathlib import Path
 # --- IB Connection ---
 IB_HOST = "127.0.0.1"
 IB_PORT = 4002  # Paper trading port
-IB_CLIENT_ID = 77
+
+# Dedicated client IDs for different jobs/examples
+IB_CLIENT_IDS = {
+    "default": 77,
+    "streamer": 17,
+    "contract_details_backfill": 8,
+    "ib_source": 101,
+    "contracts_backfill": 1,
+}
+
+# Fallback client id
+IB_CLIENT_ID = IB_CLIENT_IDS["default"]
 
 # --- Data Paths ---
 DATA_ROOT = Path("data")

--- a/ibx_flows/contracts_backfill_refactored.py
+++ b/ibx_flows/contracts_backfill_refactored.py
@@ -10,6 +10,8 @@ from typing import Iterable, List, Optional, Sequence, Set, Dict, Any, Callable
 
 import pandas as pd
 
+from config import IB_HOST, IB_PORT, IB_CLIENT_IDS, CONTRACTS_PATH
+
 # --- ibx runtime/services (kept as-is to match your project layout) ---
 try:
     from ibx import IBRuntime, ContractDetailsService
@@ -32,9 +34,9 @@ log = logging.getLogger("contracts_backfill")
 @dataclass
 class BackfillConfig:
     # IB connection
-    host: str = "127.0.0.1"
-    port: int = 7497
-    client_id: int = 1
+    host: str = IB_HOST
+    port: int = IB_PORT
+    client_id: int = IB_CLIENT_IDS["contracts_backfill"]
 
     # Filters
     exchanges: Sequence[str] = field(default_factory=lambda: ["NYSE", "NASDAQ", "ARCA", "BATS", "ISLAND", "SMART"])
@@ -51,7 +53,7 @@ class BackfillConfig:
     timeout_sec: float = 20.0
 
     # Storage
-    out_path: str = "data/contracts"  # hive-partitioned parquet dataset
+    out_path: str = str(CONTRACTS_PATH)  # hive-partitioned parquet dataset
 
     def normalized(self) -> "BackfillConfig":
         # ensure upper-case filters

--- a/ibx_flows/source_ib.py
+++ b/ibx_flows/source_ib.py
@@ -12,6 +12,7 @@ except Exception:
     from ibx.runtime import IBRuntime  # type: ignore
     from ibx.services import ContractDetailsService, SecDefService, HistoricalService  # type: ignore
     from ibx.contracts import make_stock, make_option  # type: ignore
+from config import IB_HOST, IB_PORT, IB_CLIENT_IDS
 
 def _duration_for(start: date, end: date, bar_size: str) -> str:
     days = max(1, (end - start).days + 1)
@@ -51,9 +52,9 @@ class _Pacer:
 
 @dataclass
 class IBSource:
-    host: str = "127.0.0.1"
-    port: int = 7497
-    client_id: int = 101
+    host: str = IB_HOST
+    port: int = IB_PORT
+    client_id: int = IB_CLIENT_IDS["ib_source"]
     max_hist_per_min: int = 40
 
     def __post_init__(self):

--- a/jobs/jobs_contract_details_backfill.py
+++ b/jobs/jobs_contract_details_backfill.py
@@ -30,16 +30,18 @@ def make_contract_by_conid(conid: int):
 
 from contract_descriptions_repo import ContractDescriptionsRepo
 from contract_details_repo import ContractDetailsRepo
+from config import IB_HOST, IB_PORT, IB_CLIENT_IDS, DATA_ROOT
 
 log = logging.getLogger("jobs.contract_details_backfill")
 
+
 @dataclass
 class Config:
-    host: str = "127.0.0.1"
-    port: int = 7497
-    client_id: int = 8
-    desc_path: str = "data/contract_descriptions"
-    out_path: str = "data/contract_details"
+    host: str = IB_HOST
+    port: int = IB_PORT
+    client_id: int = IB_CLIENT_IDS["contract_details_backfill"]
+    desc_path: str = str(DATA_ROOT / "contract_descriptions")
+    out_path: str = str(DATA_ROOT / "contract_details")
     timeout: float = 20.0
     as_of: dt.date = dt.date.today()
     queries: List[str] | None = None
@@ -70,11 +72,11 @@ def map_detail_row(cd: Any, as_of: dt.date) -> Dict[str, Any]:
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--host", default="127.0.0.1")
-    ap.add_argument("--port", type=int, default=7497)
-    ap.add_argument("--client-id", type=int, default=8)
-    ap.add_argument("--desc-path", default="data/contract_descriptions")
-    ap.add_argument("--out", default="data/contract_details")
+    ap.add_argument("--host", default=IB_HOST)
+    ap.add_argument("--port", type=int, default=IB_PORT)
+    ap.add_argument("--client-id", type=int, default=IB_CLIENT_IDS["contract_details_backfill"])
+    ap.add_argument("--desc-path", default=str(DATA_ROOT / "contract_descriptions"))
+    ap.add_argument("--out", default=str(DATA_ROOT / "contract_details"))
     ap.add_argument("--timeout", type=float, default=20.0)
     ap.add_argument("--queries", default="")
     ap.add_argument("--sec-types", default="")

--- a/streamer.py
+++ b/streamer.py
@@ -13,18 +13,19 @@ from request_sequencer import RequestSequencer
 from response_sequencer import ResponseSequencer
 from sink import Sink, EquityBarSink
 from utils import RateLimiter, make_stock, make_option
+from config import IB_HOST, IB_PORT, IB_CLIENT_IDS, DATA_ROOT
 
 
 @dataclass
 class Config:
     symbol: str
     date: dt.date
-    host: str = "127.0.0.1"
-    port: int = 7497
-    client_id: int = 17
+    host: str = IB_HOST
+    port: int = IB_PORT
+    client_id: int = IB_CLIENT_IDS["streamer"]
     days_before: int = 30
     days_after: int = 5
-    out_dir: Path = Path("./earnings_data")
+    out_dir: Path = DATA_ROOT
 
 class EarningsStreamer:
     # symbol: str


### PR DESCRIPTION
## Summary
- centralize Interactive Brokers configuration with dedicated client IDs
- wire streamer, backfill jobs, and sources to use shared config instead of hard-coded values
- derive data paths from common config

## Testing
- `PYTHONPATH=. pytest tests/test_app.py -q`
- `PYTHONPATH=. pytest -q` *(fails: RuntimeError: IB not ready (nextValidId not received))*

------
https://chatgpt.com/codex/tasks/task_e_689b1aac9ec08320bb532e9fe7105d68