### PR TITLE
Handle empty PyArrow datasets in repositories

### DIFF
--- a/ibx_repos-0.1.9/ibx_repos/chains.py
+++ b/ibx_repos-0.1.9/ibx_repos/chains.py
@@ -8,6 +8,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pyarrow.dataset as ds
 
+from ._util import _write_empty_dataset
+
 import pyarrow.dataset as ds
 import pandas as pd
 from datetime import date, datetime
@@ -132,6 +134,8 @@ class OptionChainSnapshotRepository:
             pa.field('strikes', pa.list_(pa.float64())),
             pa.field('snapshot_date', pa.date32()),
         ])
+        if not any(self.base_path.rglob("*.parquet")):
+            _write_empty_dataset(self.base_path, self.schema)
 
     # ----- your save() is fine; keep it as-is -----
     def save(self, underlying: str, underlying_conid: int, snapshots: List[Dict[str, Any]], snapshot_date: Optional[date] = None) -> None:
@@ -168,6 +172,7 @@ class OptionChainSnapshotRepository:
             str(self.base_path),
             format="parquet",
             partitioning=ds.partitioning(flavor="hive", schema=part_schema),
+            schema=self.schema,
         )
 
     # ----- robust load() that casts scalars to column types -----

--- a/tests/test_present_dates.py
+++ b/tests/test_present_dates.py
@@ -23,6 +23,14 @@ def test_equity_present_dates(tmp_path):
     assert present == {date(2023, 1, 1), date(2023, 1, 2)}
 
 
+def test_equity_present_dates_empty(tmp_path):
+    repo = EquityBarRepository(tmp_path)
+    present = repo.present_dates(
+        "AAPL", "1 day", pd.Timestamp("2023-01-01"), pd.Timestamp("2023-01-03")
+    )
+    assert present == set()
+
+
 def test_option_present_dates(tmp_path):
     repo = OptionBarRepository(tmp_path)
     meta = OptionMeta(
@@ -53,3 +61,17 @@ def test_option_present_dates(tmp_path):
         pd.Timestamp("2023-01-03"),
     )
     assert present == {date(2023, 1, 1), date(2023, 1, 2)}
+
+
+def test_option_present_dates_empty(tmp_path):
+    repo = OptionBarRepository(tmp_path)
+    present = repo.present_dates_for_contract(
+        "AAPL",
+        date(2023, 1, 20),
+        "C",
+        100.0,
+        "1 day",
+        pd.Timestamp("2023-01-01"),
+        pd.Timestamp("2023-01-03"),
+    )
+    assert present == set()


### PR DESCRIPTION
## Summary
- Initialize parquet repositories with empty datasets to prevent pyarrow FieldRef errors
- Include schema when opening datasets
- Add tests for `present_dates` methods with empty repositories

## Testing
- `pytest tests/test_present_dates.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ibx_flows'; RuntimeError: IB not ready)*

------
https://chatgpt.com/codex/tasks/task_e_689b206d5a508320812d94c87f627e49